### PR TITLE
Create output map for empty system

### DIFF
--- a/index.html
+++ b/index.html
@@ -1183,6 +1183,9 @@
                         m.fitBounds(pl.getBounds(), { padding: [10,10] });
                     } else if (currentLocation) {
                         m.setView(currentLocation.latlng, 16);
+                    } else {
+                        // Fallback view when there is no geometry or current GPS location
+                        m.setView([35.6892, 51.3890], 13); // Tehran default
                     }
                     setTimeout(() => m.invalidateSize(), 100);
                     return m;
@@ -1194,7 +1197,7 @@
                 renderLeafletStatic('print-traffic-map', L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { crossOrigin: 'anonymous' }));
 
                 // تبدیل صفحه به تصویر A4 و دانلود
-                await new Promise(r => setTimeout(r, 600));
+                await new Promise(r => setTimeout(r, 1200));
                 const pageEl = document.querySelector('#print-output .page');
                 const canvas = await html2canvas(pageEl, { useCORS: true, backgroundColor: '#ffffff', scale: 2 });
                 const dataURL = canvas.toDataURL('image/png');

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'gps-mapper-v1';
+const CACHE_NAME = 'gps-mapper-v2';
 const urlsToCache = [
   '/',
   '/index.html',
@@ -22,6 +22,17 @@ self.addEventListener('install', function(event) {
       .then(function(cache) {
         return cache.addAll(urlsToCache);
       })
+  );
+});
+
+// Clean up old caches on activate
+self.addEventListener('activate', function(event) {
+  event.waitUntil(
+    caches.keys().then(function(keys) {
+      return Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      );
+    })
   );
 });
 


### PR DESCRIPTION
Add a fallback center and increase render wait for print maps to prevent blank output, and update service worker cache to ensure changes are applied.

The print maps were appearing blank because when no GPS points or geometries were present, the map view was not initialized, leading to an empty canvas capture. Increasing the render wait time also ensures map tiles have fully loaded before `html2canvas` captures the image. The service worker update ensures these client-side changes are immediately reflected for users.

---
<a href="https://cursor.com/background-agent?bcId=bc-762e711f-8528-4fb4-ba6c-4e0a78f3b024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-762e711f-8528-4fb4-ba6c-4e0a78f3b024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

